### PR TITLE
Add split and double down logic

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,8 @@ import React, { useState, useEffect, useCallback } from 'react';
 import './App.css';
 import './cardstarter.css';
 import StartScreen from './StartScreen';
+import PlayerHand from './components/PlayerHand/PlayerHand';
+import DealerHand from './components/DealerHand/DealerHand';
 
 const deckData = [
   "dA", "dQ", "dK", "dJ", "d10", "d09", "d08", "d07", "d06", "d05", "d04", "d03", "d02",
@@ -21,6 +23,9 @@ const Blackjack = ({ numPlayers }) => {
   const [playerScore, setPlayerScore] = useState(0);
   const [dealerScore, setDealerScore] = useState(0);
   const [gameOver, setGameOver] = useState(false);
+  const [splitHand, setSplitHand] = useState([]);
+  const [splitScore, setSplitScore] = useState(0);
+  const [isSplit, setIsSplit] = useState(false);
 
   const cardLookup = (card) => {
     const cardValueStr = card.slice(1);
@@ -47,12 +52,6 @@ const Blackjack = ({ numPlayers }) => {
     return total;
   };
   
-  const renderCardRow = (hand) => {
-    // Map the cards 
-    return hand.map((card, i) => (
-      <div key={i} className={`card ${card} w-24 h-36 sm:w-16 sm:h-24`}></div>
-    ));
-  };
 
   const handleBet = (betAmount) => {
     if (playerBank >= betAmount) {
@@ -64,6 +63,9 @@ const Blackjack = ({ numPlayers }) => {
       setStatus(`Player Bet is $${betAmount}, Press Deal`);
       setCurrentBet(betAmount);
       setPlayerBank(playerBank - betAmount);
+      setSplitHand([]);
+      setSplitScore(0);
+      setIsSplit(false);
     } else {
       setStatus(`You don't have enough money. Game over.`);
     }
@@ -89,9 +91,12 @@ const Blackjack = ({ numPlayers }) => {
   
 
   const initialDeal = () => {
-    if (!gameOver && playerHand.length === 0 && dealerHand.length === 0) { 
+    if (!gameOver && playerHand.length === 0 && dealerHand.length === 0) {
       let tempPlayerHand = [];
       let tempDealerHand = [];
+      setSplitHand([]);
+      setSplitScore(0);
+      setIsSplit(false);
       for (let i = 0; i < 2; i++) { 
         tempPlayerHand.push(selectCard());
         tempDealerHand.push(selectCard());
@@ -142,16 +147,58 @@ const Blackjack = ({ numPlayers }) => {
     }
   };
 
+  const dealerPlay = (score) => {
+    let newDealerHand = [...dealerHand];
+    while (computeHandTotal(newDealerHand) <= 17) {
+      newDealerHand.push(selectCard());
+    }
+    setDealerHand(newDealerHand);
+    const newDealerScore = computeHandTotal(newDealerHand);
+    setDealerScore(newDealerScore);
+    renderWin(score, newDealerScore);
+  };
+
   const stand = () => {
     if (!gameOver && playerHand.length > 0) {
-      let newDealerHand = [...dealerHand];
-      while (computeHandTotal(newDealerHand) <= 17) {
-        newDealerHand.push(selectCard());
-      }
-      setDealerHand(newDealerHand);
-      const newDealerScore = computeHandTotal(newDealerHand);
-      setDealerScore(newDealerScore);
-      renderWin(playerScore, newDealerScore);
+      const finalScore = isSplit ? Math.max(playerScore, splitScore) : playerScore;
+      dealerPlay(finalScore);
+      setIsSplit(false);
+    }
+  };
+
+  const doubleDown = () => {
+    if (!gameOver && playerHand.length === 2 && playerBank >= currentBet) {
+      setPlayerBank(playerBank - currentBet);
+      setCurrentBet(currentBet * 2);
+      dealCard(playerHand, (newHand) => {
+        setPlayerHand(newHand);
+        const newScore = computeHandTotal(newHand);
+        setPlayerScore(newScore);
+        if (isSplit) {
+          setSplitScore(newScore);
+        }
+        dealerPlay(isSplit ? Math.max(newScore, splitScore) : newScore);
+      });
+    }
+  };
+
+  const splitHandAction = () => {
+    if (
+      !gameOver &&
+      playerHand.length === 2 &&
+      cardLookup(playerHand[0]) === cardLookup(playerHand[1]) &&
+      playerBank >= currentBet
+    ) {
+      setPlayerBank(playerBank - currentBet);
+      setCurrentBet(currentBet * 2);
+      const first = [playerHand[0], selectCard()];
+      const second = [playerHand[1], selectCard()];
+      setPlayerHand(first);
+      setPlayerScore(computeHandTotal(first));
+      setSplitHand(second);
+      setSplitScore(computeHandTotal(second));
+      setIsSplit(true);
+      setStatus('Split hand - playing first hand');
     }
   };
 
@@ -203,22 +250,10 @@ const Blackjack = ({ numPlayers }) => {
         <div className="text-white text-4xl" id="playerBank">Blackjack</div>
         <div className="text-white text-4xl" id="playerBank">Pays 3 to 2</div>
       </div>
-  
-      <div className="pt-24" id="dealer-cards">
-        {renderCardRow(dealerHand)}
-      </div>
-      {gameOver && (
-        <div className={`score ${gameOver ? 'visible' : ''}`} id="dealerhandvalue">
-          {dealerScore}
-        </div>
-      )}
-  
-  <div className="text-white text-xl pt-4 pb-4" id="status">{status}</div>
-      <div className="p-0 m-0" id="player-cards">
-        {renderCardRow(playerHand)}
-      </div>
-      <div className="text-white text-4xl" id="playerhandvalue">{playerScore}</div>
-  
+        <DealerHand hand={dealerHand} score={dealerScore} showScore={gameOver} />
+        <div className="text-white text-xl pt-4 pb-4" id="status">{status}</div>
+        <PlayerHand hand={playerHand} score={playerScore} />
+
       <div className="fixed bottom-0 left-0 right-0 flex flex-col items-center py-2">
 
       <div className="flex space-x-4 mb-4">
@@ -230,6 +265,8 @@ const Blackjack = ({ numPlayers }) => {
           }}>Deal</button>
         <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" onClick={hit}>Hit</button>
         <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" onClick={stand}>Stand</button>
+        <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" onClick={doubleDown}>Double</button>
+        <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" onClick={splitHandAction}>Split</button>
         <button className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" onClick={resetGame}>Reset</button>
       </div>
   

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders start game button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const buttonElement = screen.getByRole('button', { name: /start game/i });
+  expect(buttonElement).toBeInTheDocument();
 });

--- a/src/components/DealerHand/DealerHand.js
+++ b/src/components/DealerHand/DealerHand.js
@@ -1,0 +1,22 @@
+// /home/harvest/hack/react-jack/src/components/DealerHand/DealerHand.js
+import React from 'react';
+import './DealerHand.css';
+
+const DealerHand = ({ hand, score, showScore }) => {
+  return (
+    <>
+      <div className="pt-24" id="dealer-cards">
+        {hand.map((card, i) => (
+          <div key={i} className={`card ${card} w-24 h-36 sm:w-16 sm:h-24`}></div>
+        ))}
+      </div>
+      {showScore && (
+        <div className={`score ${showScore ? 'visible' : ''}`} id="dealerhandvalue">
+          {score}
+        </div>
+      )}
+    </>
+  );
+};
+
+export default DealerHand;

--- a/src/components/PlayerHand/PlayerHand.js
+++ b/src/components/PlayerHand/PlayerHand.js
@@ -1,0 +1,18 @@
+// /home/harvest/hack/react-jack/src/components/PlayerHand/PlayerHand.js
+import React from 'react';
+import './PlayerHand.css';
+
+const PlayerHand = ({ hand, score }) => {
+  return (
+    <>
+      <div className="p-0 m-0" id="player-cards">
+        {hand.map((card, i) => (
+          <div key={i} className={`card ${card} w-24 h-36 sm:w-16 sm:h-24`}></div>
+        ))}
+      </div>
+      <div className="text-white text-4xl" id="playerhandvalue">{score}</div>
+    </>
+  );
+};
+
+export default PlayerHand;


### PR DESCRIPTION
## Summary
- support double-down play by doubling bet and resolving immediately
- scaffold split hand support and track secondary hand state
- extract dealer logic into reusable helper and add UI controls for new actions

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_689282ae50b8832e99e96812af5cb259